### PR TITLE
update message to be grammatically correct for 1 ticket (fixes #2)

### DIFF
--- a/unowned.py
+++ b/unowned.py
@@ -20,7 +20,7 @@ tickets = tracker.search(
     Queue=rt.ALL_QUEUES, order="-Created", raw_query=unowned_query, Format="s"
 )
 if tickets:
-    message = f"There are currently {len(tickets)} unowned tickets:\n"
+    message = f"The number of unowned tickets is currently {len(tickets)}:\n"
     for ticket in tickets:
         message += f"- <{url}Ticket/Display.html?id={ticket['numerical_id']}|{ticket['numerical_id']} - {ticket['Subject']}>\n"
     payload = {"text": message}


### PR DESCRIPTION
Following @chryswoods advice, changing the message to 

> The number of unowned tickets is currently $n

means it is always correct for n >= 1